### PR TITLE
Camera follows vehicles

### DIFF
--- a/Vehicles/12x12.tscn
+++ b/Vehicles/12x12.tscn
@@ -141,3 +141,7 @@ visible = false
 position = Vector2( 0, 1.081 )
 z_index = 2
 shape = SubResource( 2 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/Vehicles/Bike.tscn
+++ b/Vehicles/Bike.tscn
@@ -49,3 +49,7 @@ texture = ExtResource( 4 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 z_index = 2
 shape = SubResource( 2 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/Vehicles/Car.tscn
+++ b/Vehicles/Car.tscn
@@ -58,3 +58,7 @@ texture = ExtResource( 4 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 z_index = 2
 shape = SubResource( 2 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/Vehicles/Forklift.tscn
+++ b/Vehicles/Forklift.tscn
@@ -57,3 +57,7 @@ texture = ExtResource( 4 )
 position = Vector2( 0, -9.26 )
 z_index = 2
 shape = SubResource( 2 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/Vehicles/Truck.tscn
+++ b/Vehicles/Truck.tscn
@@ -71,3 +71,7 @@ texture = ExtResource( 4 )
 position = Vector2( 0, 1.081 )
 z_index = 2
 shape = SubResource( 2 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/Vehicles/Vehicle.gd
+++ b/Vehicles/Vehicle.gd
@@ -24,11 +24,11 @@ func _ready():
 	get_tree().set_group(wheel_group, "center_steering", center_steering)
 
 
-func _process(delta):
+func _process(_delta):
 	right = global_transform.x.normalized()
 
 
-func _physics_process(delta):
+func _physics_process(_delta):
 	# acceleration input
 	var drive_input = 0
 	if Input.is_action_pressed("accelerate"):

--- a/Vehicles/Wheel.gd
+++ b/Vehicles/Wheel.gd
@@ -19,14 +19,14 @@ onready var last_position = global_position
 onready var linear_velocity = global_position - last_position
 
 
-func _process(delta):
+func _process(_delta):
 	# update direction unit vectors and position vector relative to body
 	forward = -(global_transform.y.normalized())
 	right = global_transform.x.normalized()
 	player_to_wheel = global_position - vehicle.global_position
 
 
-func _physics_process(delta):
+func _physics_process(_delta):
 	# get approximate velocity vector
 	linear_velocity = global_position - last_position
 	last_position = global_position

--- a/World.tscn
+++ b/World.tscn
@@ -21,6 +21,7 @@ scale = Vector2( 10, 10 )
 texture = ExtResource( 1 )
 
 [node name="Track" type="Sprite" parent="."]
+position = Vector2( 0, -4.20483 )
 scale = Vector2( 2, 2 )
 texture = ExtResource( 2 )
 
@@ -118,17 +119,6 @@ texture = ExtResource( 3 )
 position = Vector2( 389.877, 700.738 )
 texture = ExtResource( 6 )
 
-[node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2( 1.82727, 851.151 )
-current = true
-zoom = Vector2( 2, 2 )
-process_mode = 0
-smoothing_speed = 20.0
-drag_margin_left = 0.0
-drag_margin_top = 0.0
-drag_margin_right = 0.0
-drag_margin_bottom = 0.0
-
 [node name="Truck" parent="." instance=ExtResource( 11 )]
-position = Vector2( 560.441, 1602.62 )
-rotation = 5.75958
+position = Vector2( 487.329, 1549.87 )
+rotation = 1.5708


### PR DESCRIPTION
removed Camera2D from world scene

Added a Camera2D inside each vehicle scene and marked as current camera.

Issues may arise if two vehicles are placed in world scene during runtime.